### PR TITLE
fix(developerCredit): delete border style #65

### DIFF
--- a/Scenes/DeveloperCredits.js
+++ b/Scenes/DeveloperCredits.js
@@ -73,13 +73,11 @@ const styles = StyleSheet.create({
     container: {
         flex: 1,
         backgroundColor: "#292840",
-        borderStyle: "dashed",
         alignItems: "center",
     },
     credits: {
         alignItems: "center",
         padding: 10,
-        borderStyle: "dashed",
         borderColor: "#F2D379",
     },
     contentLayout: {


### PR DESCRIPTION
## Changes



1. delete border style from container and credit


## Purpose

The border style somehow create white screen cover on ios development credit page

## Approach

By deleting border style we are able to delete the white background


