### PR TITLE
Hsf 78 calculate lives

### DIFF
--- a/Components/GenerateQuestion.js
+++ b/Components/GenerateQuestion.js
@@ -7,7 +7,7 @@ import { connect } from "react-redux";
 import { getMovieChanges, getPerformerName } from "../Utils/FetchApi";
 import axios from "axios";
 
-const GenerateQuestion = ({ movies, setSelectedMovie }) => {
+const GenerateQuestion = ({ movies, setSelectedMovie}) => {
   useEffect(() => {
     let movie = movies ? movies[RandomGenerator(movies.length)] : [];
     axios.all([getPerformerName(movie.id), getGenreName(movie.genre_ids[0])])

--- a/Components/MultipleChoice.js
+++ b/Components/MultipleChoice.js
@@ -14,11 +14,13 @@ const MultipleChoice = ({
   selectedMovie,
   setScene,
   increaseWinningStreak,
+  decreaseWinningStreak,
   resetWinningStreak,
   lives,
   gamePlayMode,
   decreaseLives,
-  resetLives
+  resetLives,
+  winningStreak
 }) => {
   const [multipleAnswer, setMultipleAnswer] = useState(selectedMovie?.answer);
   const [correctAnswer, setCorrectAnswer] = useState("");
@@ -54,14 +56,19 @@ const MultipleChoice = ({
         setScene("CorrectAnswer");
       }, 2000);
     }
-    else if(gamePlayMode="easySinglePlayer"&&lives>1&&selection !== correctAnswer){
+    else if(gamePlayMode="easySinglePlayer"&&winningStreak>=0&&selection !== correctAnswer){
+      setTimeout(() => {
+        decreaseWinningStreak();
+        setScene("Main");
+      }, 1000);
+    }
+    else if(gamePlayMode="easySinglePlayer"&&winningStreak==-1&&lives>1&&selection !== correctAnswer){
         setTimeout(() => {
-          resetWinningStreak();
           decreaseLives();
           setScene("Main");
         }, 1000);
       }
-      else if(gamePlayMode="easySinglePlayer"&&lives==1&&selection !== correctAnswer){
+      else if(gamePlayMode="easySinglePlayer"&&winningStreak==-1&&lives==1&&selection !== correctAnswer){
         setTimeout(() => {
           resetWinningStreak();
           resetLives();
@@ -105,6 +112,7 @@ const MultipleChoice = ({
       return "line-through";
     }
   };
+
   return (
     <View>
       {multipleAnswer.map((item, index) => (
@@ -133,6 +141,7 @@ const mapStateToProps = (state) => ({
   selectedMovie: state.selectedMovie,
   lives:state.lives,
   gamePlayMode:state.gamePlayMode||"easySinglePlayer",
+  winningStreak:state.winningStreak
 });
 
 function mapDispatchToProps(dispatch) {
@@ -145,6 +154,10 @@ function mapDispatchToProps(dispatch) {
     increaseWinningStreak: () =>
       dispatch({
         type: "INCREASE_WINNING_STREAK",
+      }),
+    decreaseWinningStreak: () =>
+      dispatch({
+        type: "DECREASE_WINNING_STREAK",
       }),
     resetWinningStreak: () =>
       dispatch({

--- a/Components/MultipleChoice.js
+++ b/Components/MultipleChoice.js
@@ -15,6 +15,10 @@ const MultipleChoice = ({
   setScene,
   increaseWinningStreak,
   resetWinningStreak,
+  lives,
+  gamePlayMode,
+  decreaseLives,
+  resetLives
 }) => {
   const [multipleAnswer, setMultipleAnswer] = useState(selectedMovie?.answer);
   const [correctAnswer, setCorrectAnswer] = useState("");
@@ -49,7 +53,22 @@ const MultipleChoice = ({
         increaseWinningStreak();
         setScene("CorrectAnswer");
       }, 2000);
-    } else {
+    }
+    else if(gamePlayMode="easySinglePlayer"&&lives>1&&selection !== correctAnswer){
+        setTimeout(() => {
+          resetWinningStreak();
+          decreaseLives();
+          setScene("Main");
+        }, 1000);
+      }
+      else if(gamePlayMode="easySinglePlayer"&&lives==1&&selection !== correctAnswer){
+        setTimeout(() => {
+          resetWinningStreak();
+          resetLives();
+          setScene("GameOver");
+        }, 1000);
+      }
+    else {
       setTimeout(() => {
         resetWinningStreak();
         setScene("GameOver");
@@ -86,7 +105,6 @@ const MultipleChoice = ({
       return "line-through";
     }
   };
-
   return (
     <View>
       {multipleAnswer.map((item, index) => (
@@ -113,6 +131,8 @@ const MultipleChoice = ({
 const mapStateToProps = (state) => ({
   questions: state.questions,
   selectedMovie: state.selectedMovie,
+  lives:state.lives,
+  gamePlayMode:state.gamePlayMode||"easySinglePlayer",
 });
 
 function mapDispatchToProps(dispatch) {
@@ -130,6 +150,14 @@ function mapDispatchToProps(dispatch) {
       dispatch({
         type: "RESET_WINNING_STREAK",
       }),
+    decreaseLives: () =>
+      dispatch({
+        type: "DECREASE_LIVES",
+      }),
+    resetLives: () =>
+      dispatch({
+        type: "RESET_LIVES",
+      }),  
   };
 }
 

--- a/Components/TrueFalse.js
+++ b/Components/TrueFalse.js
@@ -14,11 +14,13 @@ const TrueFalse = ({
   selectedMovie,
   setScene,
   increaseWinningStreak,
+  decreaseWinningStreak,
   resetWinningStreak,
   lives,
   gamePlayMode,
   decreaseLives,
-  resetLives
+  resetLives,
+  winningStreak
 }) => {
   const [selectedAnswer, setSelectedAnswer] = useState();
   const answer = selectedMovie?.answer;
@@ -30,20 +32,25 @@ const TrueFalse = ({
         setScene("CorrectAnswer");
       }, 1000);
     }
-    else if(gamePlayMode="easySinglePlayer"&&lives>1&&selection !== answer){
+    else if(gamePlayMode="easySinglePlayer"&&winningStreak>=0&&selection !== answer){
       setTimeout(() => {
-        resetWinningStreak();
-        decreaseLives();
+        decreaseWinningStreak();
         setScene("Main");
       }, 1000);
     }
-    else if(gamePlayMode="easySinglePlayer"&&lives==1&&selection !== answer){
-      setTimeout(() => {
-        resetWinningStreak();
-        resetLives();
-        setScene("GameOver");
-      }, 1000);
-    }
+    else if(gamePlayMode="easySinglePlayer"&&winningStreak==-1&&lives>1&&selection !== answer){
+        setTimeout(() => {
+          decreaseLives();
+          setScene("Main");
+        }, 1000);
+      }
+      else if(gamePlayMode="easySinglePlayer"&&winningStreak==-1&&lives==1&&selection !== answer){
+        setTimeout(() => {
+          resetWinningStreak();
+          resetLives();
+          setScene("GameOver");
+        }, 1000);
+      }
     else {
       setTimeout(() => {
         resetWinningStreak();
@@ -51,6 +58,7 @@ const TrueFalse = ({
       }, 1000);
     }
   };
+
   const getIcon = (button) => {
     if (typeof selectedAnswer === "undefined") {
       return <FontAwesome name="star" size={12} color="#401323" />;
@@ -199,6 +207,7 @@ const mapStateToProps = (state) => ({
   selectedMovie: state.selectedMovie,
   lives:state.lives,
   gamePlayMode:state.gamePlayMode||"easySinglePlayer",
+  winningStreak:state.winningStreak
 });
 
 function mapDispatchToProps(dispatch) {
@@ -211,6 +220,10 @@ function mapDispatchToProps(dispatch) {
     increaseWinningStreak: () =>
       dispatch({
         type: "INCREASE_WINNING_STREAK",
+      }),
+    decreaseWinningStreak: () =>
+      dispatch({
+        type: "DECREASE_WINNING_STREAK",
       }),
     resetWinningStreak: () =>
       dispatch({

--- a/Components/TrueFalse.js
+++ b/Components/TrueFalse.js
@@ -15,6 +15,10 @@ const TrueFalse = ({
   setScene,
   increaseWinningStreak,
   resetWinningStreak,
+  lives,
+  gamePlayMode,
+  decreaseLives,
+  resetLives
 }) => {
   const [selectedAnswer, setSelectedAnswer] = useState();
   const answer = selectedMovie?.answer;
@@ -25,14 +29,28 @@ const TrueFalse = ({
         increaseWinningStreak();
         setScene("CorrectAnswer");
       }, 1000);
-    } else {
+    }
+    else if(gamePlayMode="easySinglePlayer"&&lives>1&&selection !== answer){
+      setTimeout(() => {
+        resetWinningStreak();
+        decreaseLives();
+        setScene("Main");
+      }, 1000);
+    }
+    else if(gamePlayMode="easySinglePlayer"&&lives==1&&selection !== answer){
+      setTimeout(() => {
+        resetWinningStreak();
+        resetLives();
+        setScene("GameOver");
+      }, 1000);
+    }
+    else {
       setTimeout(() => {
         resetWinningStreak();
         setScene("GameOver");
       }, 1000);
     }
   };
-
   const getIcon = (button) => {
     if (typeof selectedAnswer === "undefined") {
       return <FontAwesome name="star" size={12} color="#401323" />;
@@ -179,6 +197,8 @@ const TrueFalse = ({
 const mapStateToProps = (state) => ({
   questions: state.questions,
   selectedMovie: state.selectedMovie,
+  lives:state.lives,
+  gamePlayMode:state.gamePlayMode||"easySinglePlayer",
 });
 
 function mapDispatchToProps(dispatch) {
@@ -195,6 +215,14 @@ function mapDispatchToProps(dispatch) {
     resetWinningStreak: () =>
       dispatch({
         type: "RESET_WINNING_STREAK",
+      }),
+    decreaseLives: () =>
+      dispatch({
+        type: "DECREASE_LIVES",
+      }),
+    resetLives: () =>
+      dispatch({
+        type: "RESET_LIVES",
       }),
   };
 }

--- a/Utils/reducer.js
+++ b/Utils/reducer.js
@@ -13,6 +13,11 @@ export const reducer = (state = initialState, action) => {
         ...state,
         winningStreak: state.winningStreak + 1,
       };
+      case "DECREASE_WINNING_STREAK":
+      return {
+        ...state,
+        winningStreak: state.winningStreak - 1,
+      };
     case "RESET_WINNING_STREAK":
       return {
         ...state,


### PR DESCRIPTION
## Changes

calculate lives on using redux state

1. When out of points ( below zero) subtract one life when the user looses the game

2. When no more lives Game Over scene pops up

## Purpose

To give the user more chances to win before game over scene

## Approach
calculate lives  using redux state


Closes #78
