### PR TITLE
bug(lives text): correct sentence structure lives vs life #125

### DIFF
--- a/Scenes/WrongAnswer.js
+++ b/Scenes/WrongAnswer.js
@@ -127,7 +127,8 @@ import {
                   {"  "}
                   {lives}
                   {"  "}
-                  lives left. {"\n"}
+                  {lives > 1 ? "lives left." : "life left."}
+                  {"\n"}
                   {"\n"}Try again!
                 </Text>
               </View>


### PR DESCRIPTION
## Changes

1. Change sentence to say "lives" when more than one life is left.  Change the sentence to say "life" when one life is left.


## Purpose

Fix grammatical errors in sentence.

Closes #125
