### PR TITLE
Gsh 142 settings modal bug

### DIFF
--- a/Components/Nav.js
+++ b/Components/Nav.js
@@ -4,6 +4,7 @@ import {
   SafeAreaView,
   StatusBar,
   Platform,
+  View,
 } from "react-native";
 import { connect } from "react-redux";
 import GameOver from "../Scenes/GameOver";
@@ -18,7 +19,7 @@ import GamePlayMode from "./GamePlayMode";
 import WrongAnswer from "../Scenes/WrongAnswer";
 import HowToPlay from "../Scenes/HowToPlay";
 
-function Nav({ scene }) {
+function Nav({ scene, modalVisible }) {
   return (
     <SafeAreaView style={styles.layout}>
       <Header style={styles.header} />
@@ -39,6 +40,18 @@ function Nav({ scene }) {
       {scene !== "Question" && scene !== "CorrectAnswer" && (
         <Footer style={styles.footer} />
       )}
+      {
+        modalVisible && (
+          <View style={{
+            position: 'absolute',
+            height: "100%",
+            width: "100%",
+            opacity: 0.9,
+            backgroundColor: 'gray',
+            zIndex: 100,
+          }} /> 
+        )
+      }
     </SafeAreaView>
   );
 }
@@ -78,6 +91,7 @@ const styles = StyleSheet.create({
 function mapStateToProps(state) {
   return {
     scene: state.scene,
+    modalVisible: state.modalVisible,
   };
 }
 

--- a/Components/SettingsModal.js
+++ b/Components/SettingsModal.js
@@ -4,8 +4,7 @@ import { Modal, StyleSheet, Text, View, Pressable } from "react-native";
 import { AntDesign } from "@expo/vector-icons";
 import { Picker } from "@react-native-picker/picker";
 
-const SettingsModal = ({ scene, gamePlayMode, setGamePlayMode }) => {
-  const [modalVisible, setModalVisible] = useState(false);
+const SettingsModal = ({ scene, gamePlayMode, setGamePlayMode, modalVisible, setModalVisible }) => {
 
   return (
     <View>
@@ -21,13 +20,6 @@ const SettingsModal = ({ scene, gamePlayMode, setGamePlayMode }) => {
               setModalVisible(!modalVisible);
             }}
           >
-            <View style={{
-              position: 'absolute',
-              height: "100%",
-              width: "100%",
-              opacity: 0.9,
-              backgroundColor: 'gray',
-            }} /> 
             <View style={styles.modalView}>
               <Pressable
                 style={styles.exit}
@@ -66,7 +58,8 @@ const SettingsModal = ({ scene, gamePlayMode, setGamePlayMode }) => {
 function mapStateToProps(state) {
   return {
     scene: state.scene,
-    gamePlayMode: state.gamePlayMode
+    gamePlayMode: state.gamePlayMode,
+    modalVisible: state.modalVisible,
   };
 }
 // this is how the picker tells redux that the user has selected a new player mode
@@ -78,6 +71,12 @@ function mapDispatchToProps(dispatch) {
         // type or action or action type, payload
         type: 'SET_GAME_PLAY_MODE',
         gamePlayMode: mode
+      })
+    },
+    setModalVisible: (visible) => {
+      dispatch({
+        type: 'SET_MODAL_VISIBLE',
+        modalVisible: visible
       })
     }
   }

--- a/Components/SettingsModal.js
+++ b/Components/SettingsModal.js
@@ -14,13 +14,20 @@ const SettingsModal = ({ scene, gamePlayMode, setGamePlayMode }) => {
       ) : (
         <>
           <Modal
-            animationType="slide"
+            animationType="fade"
             transparent={true}
             visible={modalVisible}
             onRequestClose={() => {
               setModalVisible(!modalVisible);
             }}
           >
+            <View style={{
+              position: 'absolute',
+              height: "100%",
+              width: "100%",
+              opacity: 0.9,
+              backgroundColor: 'gray',
+            }} /> 
             <View style={styles.modalView}>
               <Pressable
                 style={styles.exit}

--- a/Utils/reducer.js
+++ b/Utils/reducer.js
@@ -5,6 +5,7 @@ const initialState = {
   selectedMovie: {},
   gamePlayMode: "singlePlayer",
   lives: 3,
+  modalVisible: false,
 };
 
 export const reducer = (state = initialState, action) => {
@@ -64,6 +65,11 @@ export const reducer = (state = initialState, action) => {
         ...state,
         lives: 3,
       };
+    case "SET_MODAL_VISIBLE":
+      return {
+        ...state,
+        modalVisible: action.modalVisible,
+      }
   }
   return state;
 };


### PR DESCRIPTION
## Changes

The changes that we made in this ticket was putting a grey backdrop behind the modal to help show the user that nothing behind the modal is accessible when the modal is visible.

1. Nav.js
2. SettingsModal.js
3. Reducer.js

## Purpose

The purpose of this ticket was to better indicate that you cannot access anything behind the modal, before we added the backdrop there was nothing present behind the modal, which may have confused the user or even made them think they can access multiple features while the modal was visible which is not the intentions of the functionality when the modal is visible.

## Approach

The approach when creating this feature was to find the view the modal was in and give it a background only when the modal was visible.

Closes #142
