### PR TITLE
feat(Question.js) : move live icon below the movie-drive in screen & …

### DIFF
--- a/Components/Lives.js
+++ b/Components/Lives.js
@@ -11,7 +11,7 @@ function Lives({ lives }) {
         <MaterialCommunityIcons
             style={styles.livesIcon}
             name="popcorn"
-            size={35}
+            size={28}
             key={i}
         />  
     );

--- a/Scenes/Question.js
+++ b/Scenes/Question.js
@@ -77,17 +77,20 @@ function Question({ selectedMovie, movies, setMovies, movieId, gamePlayMode }) {
               : styles.questionFooterMobile,
           ]}
         >
+
+          {/* then enable lives */}
+          
+        </View>
+        <View style={styles.indicators}>
           {gamePlayMode === "easySinglePlayer" && (
             <View style={styles.lives}>
               <Lives />
             </View>
           )}
-          {/* then enable lives */}
           <View style={styles.badge}>
             <Badge />
           </View>
         </View>
-
         <View
           style={[
             width > widthBreakpoint ? styles.titleWrap : styles.titleWrapMobile,
@@ -192,7 +195,6 @@ const styles = StyleSheet.create({
     alignSelf: "center",
     marginTop: 10,
     textAlign: "center",
-    color: "#F2D379",
     fontFamily: "Limelight_400Regular",
     fontSize: 30,
   },
@@ -203,13 +205,14 @@ const styles = StyleSheet.create({
   },
   badge: {
     position: "absolute",
-    bottom: 0,
-    right: 0,
+    top: 15,
+    right: 50,
   },
   lives: {
     position: "absolute",
-    bottom: 0,
-    left: 0,
+    top: -5,
+    left: 50,
+    
   },
   questionHeader: {
     flexDirection: "row",
@@ -229,6 +232,15 @@ const styles = StyleSheet.create({
     alignItems: "center",
     alignSelf: "center",
     width: "75%",
+  },
+  indicators: {
+    marginTop: Platform.OS === "web" ? 10 : 5,
+    minWidth: 375, // 320px is iPhone 5/SE size
+    width: "50%",
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "space-around",
+    
   },
 });
 

--- a/Scenes/WrongAnswer.js
+++ b/Scenes/WrongAnswer.js
@@ -255,7 +255,7 @@ const styles = StyleSheet.create({
   indicators: {
     marginTop: Platform.OS === "web" ? 30 : 10,
     minWidth: 375, // 320px is iPhone 5/SE size
-    width: "50%",
+    width: "100%",
     display: "flex",
     flexDirection: "row",
     justifyContent: "space-around",


### PR DESCRIPTION
…change the icon size to 28 #157

## Changes

1. Moved the lives icon below the drive-in movie screen on both Questions and WrongAnswer.js scenes. 
2. Changed the lives icon size from 35 to 28 to fit the screen on Android and IOS devices for better visual. 


## Purpose

The Lives icons appear inside the drive-in move screen on the Question scenes.

## Approach

By placing The lives icon  below the drive-in movie screen, it helps users to see their lives and stric points at all times. 


 #157
