### PR TITLE
Js 147 game over space

### DIFF
--- a/Components/GamePlayMode.js
+++ b/Components/GamePlayMode.js
@@ -1,7 +1,9 @@
-import { View, Text, StyleSheet, Platform } from "react-native";
+import { View, Text, StyleSheet, Platform, useWindowDimensions } from "react-native";
 import { connect } from "react-redux";
 
 function GamePlayMode({ gamePlayMode }) {
+
+  const { height } = useWindowDimensions();
 
   let currentMode = "";
     switch(gamePlayMode) {
@@ -15,8 +17,11 @@ function GamePlayMode({ gamePlayMode }) {
   return (
     <View style={[styles.container,
       {top: Platform.OS === "ios" && height === "1334px" 
-      ? 40 : Platform.OS === "ios" 
-      ? 48 : 30}]
+        ? 40 
+        : Platform.OS === "ios" 
+        ? 48 : 30
+      }
+    ]
     }>
       <Text style={styles.gamePlayText}>{currentMode}</Text>
     </View>

--- a/Components/GamePlayMode.js
+++ b/Components/GamePlayMode.js
@@ -13,7 +13,11 @@ function GamePlayMode({ gamePlayMode }) {
     }
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container,
+      {top: Platform.OS === "ios" && height === "1334px" 
+      ? 40 : Platform.OS === "ios" 
+      ? 48 : 30}]
+    }>
       <Text style={styles.gamePlayText}>{currentMode}</Text>
     </View>
   

--- a/Scenes/GameOver.js
+++ b/Scenes/GameOver.js
@@ -58,6 +58,7 @@ function GameOver({ setScene, resetWinningStreak, resetSelectedMovie }) {
         <Image
           source={MilkyWay}
           style={[styles.milkywaybg, { marginBottom: (height - 40) * -1 }]}
+          resizeMode='cover'
         ></Image>
         <Image
           source={DriveInForeground}
@@ -113,8 +114,8 @@ const styles = StyleSheet.create({
   },
   milkywaybg: {
     width: "100%",
-    maxHeight: "50%",
-    aspectRatio: 468 / 272,
+    height: "80%",
+    // aspectRatio: 468 / 272,
   },
   driveinforeground: {
     position: "absolute",

--- a/Scenes/GameOver.js
+++ b/Scenes/GameOver.js
@@ -114,7 +114,7 @@ const styles = StyleSheet.create({
   },
   milkywaybg: {
     width: "100%",
-    height: "80%",
+    height: "60%",
     // aspectRatio: 468 / 272,
   },
   driveinforeground: {

--- a/Scenes/GameOver.js
+++ b/Scenes/GameOver.js
@@ -113,6 +113,7 @@ const styles = StyleSheet.create({
   },
   milkywaybg: {
     width: "100%",
+    maxHeight: "50%",
     aspectRatio: 468 / 272,
   },
   driveinforeground: {

--- a/Utils/reducer.js
+++ b/Utils/reducer.js
@@ -1,6 +1,6 @@
 const initialState = {
   winningStreak: 0,
-  scene: "GameOver",
+  scene: "Main",
   movies: [],
   selectedMovie: {},
   gamePlayMode: "singlePlayer",

--- a/Utils/reducer.js
+++ b/Utils/reducer.js
@@ -1,6 +1,6 @@
 const initialState = {
   winningStreak: 0,
-  scene: "Main",
+  scene: "GameOver",
   movies: [],
   selectedMovie: {},
   gamePlayMode: "singlePlayer",


### PR DESCRIPTION
## Changes

1. Set a `height` to the `milkywaybg` image to `60%`
2. Also set `resizeMode` to `cover` on the `milkywaybg` image
3. Turned the `aspectRatio` off

## Purpose

To fix the problem with the `milkywaybg` image displaying at the bottom of the `GameOver` scene. 

## Approach

This change makes it so the `milkywaybg` image no longer displays at the bottom of the scene.

Closes #147
