### PR TITLE
Ajm 156 state update sound bug

### DIFF
--- a/Components/Clock.js
+++ b/Components/Clock.js
@@ -2,7 +2,7 @@ import * as React from "react";
 import { Text, View, StyleSheet, Platform } from "react-native";
 import { CountdownCircleTimer } from "react-native-countdown-circle-timer";
 
-export default function App() {
+export default function Clock() {
   const [isPlaying, setIsPlaying] = React.useState(true);
 
   return (

--- a/Components/Clock.js
+++ b/Components/Clock.js
@@ -1,10 +1,7 @@
-import * as React from "react";
 import { Text, View, StyleSheet, Platform } from "react-native";
 import { CountdownCircleTimer } from "react-native-countdown-circle-timer";
 
-export default function Clock() {
-  const [isPlaying, setIsPlaying] = React.useState(true);
-
+export default function Clock({ isPlaying, onUpdate, onComplete }) {
   return (
     <View style={styles.container}>
       <CountdownCircleTimer
@@ -12,10 +9,11 @@ export default function Clock() {
         duration={10}
         colors={["#F2D379", "#CA3D45"]}
         colorsTime={[10, 0]}
-        onComplete={() => ({ shouldRepeat: false, delay: 2 })}
+        onComplete={onComplete}
         size={50}
         strokeWidth={6}
         trailColor={"#CA3D45"}
+        onUpdate={onUpdate}
       >
         {({ remainingTime }) => (
           <Text style={{ color: "#F2D379", fontSize: 20 }}>

--- a/Components/Timer.js
+++ b/Components/Timer.js
@@ -7,60 +7,57 @@ import { StyleSheet, View, Platform } from "react-native";
 
 function Timer({ setScene }) {
   const [sound, setSound] = useState();
+  const [isPlaying, setIsPlaying] = useState(false);
 
-  async function playSound() {
-    await sound.replayAsync();
+  async function handleClockUpdate(remainingTime) {
+    if (sound && remainingTime > 0) {
+      await sound.replayAsync();
+    }
+  }
+
+  function handleClockComplete() {
+    setScene("GameOver");
   }
 
   useEffect(() => {
     const loadSound = async () => {
       try {
         const { sound } = await Audio.Sound.createAsync(tick);
+        await sound.playAsync();
+        setIsPlaying(true);
         setSound(sound);
       } catch(e) {
         console.error(e);
       }
+    
     }
     loadSound();
-  }, [])
-
-  useEffect(() => {
-    if (sound) {
-      let timerCount = 10;
-
-      const timerInterval = setInterval(() => {
-        if (timerCount > 0) {
-          playSound().then(() => {
-            timerCount -= 1;
-          });
-        } else {
-          clearTimer();
-        }
-      }, 1000);
-
-      const clearTimer = () => {
-        clearInterval(timerInterval);
-        setScene("GameOver");
-      };
-
-      return () => {
-        clearInterval(timerInterval);
-        sound ? sound.unloadAsync() : undefined;
-      };
-    }
-  }, [sound]);
+    return () => {
+      sound ? sound.unloadAsync() : undefined;
+    };
+  }, []);
 
   // Conditional render depending on OS
   if (Platform.OS === "web") {
     // Render for web
     return (
       <View style={styles.timer}>
-        <Clock />
+        <Clock
+          isPlaying={isPlaying}
+          onUpdate={handleClockUpdate}
+          onComplete={handleClockComplete}
+        />
       </View>
     );
   } else {
   // Render for ios and android
-    return <Clock />;
+    return (
+      <Clock
+        isPlaying={isPlaying}
+        onUpdate={handleClockUpdate}
+        onComplete={handleClockComplete} 
+      />
+    );
   }
 }
 

--- a/Components/Timer.js
+++ b/Components/Timer.js
@@ -10,10 +10,20 @@ function Timer({ setScene }) {
   const [sound, setSound] = useState();
 
   async function playSound() {
-    const { sound } = await Audio.Sound.createAsync(tick);
-    setSound(sound);
-    await sound.playAsync();
+    await sound.replayAsync();
   }
+
+  useEffect(() => {
+    const loadSound = async () => {
+      try {
+        const { sound } = await Audio.Sound.createAsync(tick);
+        setSound(sound);
+      } catch(e) {
+        console.error(e);
+      }
+    }
+    loadSound();
+  }, [])
 
   useEffect(() => {
     const timerInterval = setInterval(() => {

--- a/Components/Timer.js
+++ b/Components/Timer.js
@@ -6,7 +6,6 @@ import Clock from "../Components/Clock";
 import { StyleSheet, View, Platform } from "react-native";
 
 function Timer({ setScene }) {
-  const [timerCount, setTimerCount] = useState(10);
   const [sound, setSound] = useState();
 
   async function playSound() {
@@ -26,25 +25,30 @@ function Timer({ setScene }) {
   }, [])
 
   useEffect(() => {
-    const timerInterval = setInterval(() => {
-      if (timerCount > 0) {
-        setTimerCount(timerCount - 1);
-        playSound();
-      } else {
-        clearTimer();
-      }
-    }, 1000);
+    if (sound) {
+      let timerCount = 10;
 
-    const clearTimer = () => {
-      clearInterval(timerInterval);
-      setScene("GameOver");
-    };
+      const timerInterval = setInterval(() => {
+        if (timerCount > 0) {
+          playSound().then(() => {
+            timerCount -= 1;
+          });
+        } else {
+          clearTimer();
+        }
+      }, 1000);
 
-    return () => {
-      clearInterval(timerInterval);
-      sound ? sound.unloadAsync() : undefined;
-    };
-  }, [timerCount]);
+      const clearTimer = () => {
+        clearInterval(timerInterval);
+        setScene("GameOver");
+      };
+
+      return () => {
+        clearInterval(timerInterval);
+        sound ? sound.unloadAsync() : undefined;
+      };
+    }
+  }, [sound]);
 
   // Conditional render depending on OS
   if (Platform.OS === "web") {

--- a/Components/Timer.js
+++ b/Components/Timer.js
@@ -5,7 +5,8 @@ import tick from "../Sounds/tick.wav";
 import Clock from "../Components/Clock";
 import { StyleSheet, View, Platform } from "react-native";
 
-function Timer({ setScene, timerCount, setTimerCount }) {
+function Timer({ setScene }) {
+  const [timerCount, setTimerCount] = useState(10);
   const [sound, setSound] = useState();
 
   async function playSound() {

--- a/Scenes/Question.js
+++ b/Scenes/Question.js
@@ -20,7 +20,6 @@ import Badge from "../Components/Badge";
 import Lives from "../Components/Lives";
 
 function Question({ selectedMovie, movies, setMovies, movieId, gamePlayMode }) {
-  const [timerCount, setTimerCount] = useState(10);
   const { width } = useWindowDimensions();
   const widthBreakpoint = 700;
   useEffect(() => {
@@ -55,7 +54,7 @@ function Question({ selectedMovie, movies, setMovies, movieId, gamePlayMode }) {
           >
             <View style={styles.questionHeader}>
               {gamePlayMode !== "easySinglePlayer" && (
-                <Timer timerCount={timerCount} setTimerCount={setTimerCount} />
+                <Timer />
               )}
               <Text
                 style={[


### PR DESCRIPTION
## Changes

1. Remove timerCount state from Question.js
2. Add a useEffect function to initialize and play sound on component mount
3. Refactor the Clock component to accept additional props *isPlaying, onUpdate, onComplete*  
4. Add isPlaying state to control Clock countdown.
5. Simplify timer logic by replacing the setInterval logic with two function helpers, handleClockUpdate and handleClockComplete, that are handled by the Clock component. 
  * handleClockUpdate plays the tick sound every second (except for the final second to avoid overlapping with the game over sound).
  * handleClockComplete changes the scene to GameOver when all time has elapsed.

## Purpose
Resolve the cannot perform state update on unmounted component bug inside Timer.js

## Approach
Initialize and play the tick sound on component mount via useEffect.
Add isPlaying state to allow sound to load before counting down.
Add two helper functions to replay the tick sound or switch scenes on elapsed time.
There was no need for extra complexity with a setInterval function. The Clock component handles timer functionality via two props, onUpdate and onComplete.
Simplifying the timer logic improves readability and lessens the chances of further bugs with setInterval

## Learning

I used replayAsync() instead of setPositionAsync(0) and playAsync() to replay the tick sound because of how the iOS native player works
https://github.com/expo/expo/issues/1095#issuecomment-352745797

Closes #156 
