### PR TITLE
refactor(game over): remove aspect ratio from milkywaybg styles

### DIFF
--- a/Scenes/GameOver.js
+++ b/Scenes/GameOver.js
@@ -115,7 +115,6 @@ const styles = StyleSheet.create({
   milkywaybg: {
     width: "100%",
     height: "60%",
-    // aspectRatio: 468 / 272,
   },
   driveinforeground: {
     position: "absolute",


### PR DESCRIPTION
## Changes

1. Removed `aspectRatio` from the `milkywaybg` image styles

## Purpose

Just cleaning up the code by removing commented out code.

## Approach

Removed the line of code that set the aspect ratio for the `milkywaybg` image.

Closes #147
