### PR TITLE
feature(correctanswer): Added lives to the correct answer page in eas…

### DIFF
--- a/Components/Lives.js
+++ b/Components/Lives.js
@@ -54,7 +54,6 @@ export default connect(mapStateToProps, mapDispatchToProps)(Lives);
 
 const styles = StyleSheet.create({
     livesDisplay: {
-        flex: 1,
         flexDirection: "column",
 		justifyContent: "center",
 		alignItems: "center",

--- a/Scenes/CorrectAnswer.js
+++ b/Scenes/CorrectAnswer.js
@@ -6,8 +6,9 @@ import { useFonts, Limelight_400Regular } from "@expo-google-fonts/limelight";
 import ticket from "../Images/ticket.png";
 import Badge from "../Components/Badge";
 import DriveInMovie from "../Layout/DriveInMovie";
+import Lives from "../Components/Lives";
 
-const CorrectAnswer = ({ selectedMovie, setScene, resetSelectedMovie }) => {
+const CorrectAnswer = ({ selectedMovie, setScene, resetSelectedMovie, gamePlayMode }) => {
   const handleNextQuestion = () => {
     setScene("Question");
     resetSelectedMovie();
@@ -25,6 +26,9 @@ const CorrectAnswer = ({ selectedMovie, setScene, resetSelectedMovie }) => {
         screen={<Trailer movieId={selectedMovie?.movieId} />}
         indicators={
           <>
+          { gamePlayMode === 'easySinglePlayer' &&
+            <Lives/>
+          }
             <Text style={styles.h2}>Correct!</Text>
             <Badge />
           </>
@@ -44,6 +48,7 @@ const CorrectAnswer = ({ selectedMovie, setScene, resetSelectedMovie }) => {
 function mapStateToProps(state) {
   return {
     selectedMovie: state.selectedMovie,
+    gamePlayMode: state.gamePlayMode
   };
 }
 


### PR DESCRIPTION
## Changes

1. Lives.js
2. CorrectAnswer.js

## Purpose

The purpose of this ticket was to display the lives on the `CorrectAnswer` scene only while on `easySinglePlayer` mode.

## Approach

The Approach to this ticket was to examine the other scenes and see how they were currently displayed so we can match the `CorrectAnswer` scene with the rest of the `easySinglePlayer` gameplay.

## Learning

There wasn't many new concepts we had to learn to complete this ticket but while I was doing the ticket I got more hands on with redux which cleared up some questions I had before in regards to redux.

Closes #176 
