### PR TITLE
Gsh 24 genre gameplay query

### DIFF
--- a/Components/SettingsModal.js
+++ b/Components/SettingsModal.js
@@ -1,25 +1,15 @@
-import { useEffect } from "react";
+
 import { connect } from "react-redux";
 import { Modal, StyleSheet, Text, View, Pressable } from "react-native";
 import { AntDesign } from "@expo/vector-icons";
 import { Picker } from "@react-native-picker/picker";
-import { getGenre } from "../Utils/FetchApi";
 const SettingsModal = ({
   scene,
   gamePlayMode,
   setGamePlayMode,
   modalVisible,
   setModalVisible,
-  setGenre,
-  genreTypes,
-  genre,
-  setGenreTypes,
 }) => {
-  useEffect(() => {
-    getGenre().then((genreTypes) => {
-      setGenreTypes(genreTypes.data.genres);
-    });
-  }, []);
   return (
     <View>
       {scene === "Question" || scene === "CorrectAnswer" ? (
@@ -61,30 +51,6 @@ const SettingsModal = ({
                   value="easySinglePlayer"
                 />
               </Picker>
-
-              {/* Genre Picker */}
-              <Text style={styles.label}>Select a Genre</Text>
-              <Picker
-                style={styles.input}
-                selectedValue={genre == null ? "" : genre.id}
-                onValueChange={(newGenreId) => {
-                  const foundGenre = genreTypes.find(
-                    (genre) => genre.id == newGenreId
-                  );
-                  setGenre(foundGenre ? foundGenre : null);
-                }}
-              >
-                <Picker.Item label="All Genres" value="" />
-                {genreTypes.map((genre, key) => {
-                  return (
-                    <Picker.Item
-                      label={genre.name}
-                      value={genre.id}
-                      key={key}
-                    />
-                  );
-                })}
-              </Picker>
             </View>
           </Modal>
           <Pressable onPress={() => setModalVisible(true)}>
@@ -101,8 +67,6 @@ function mapStateToProps(state) {
     scene: state.scene,
     gamePlayMode: state.gamePlayMode,
     modalVisible: state.modalVisible,
-    genreTypes: state.genreTypes,
-    genre: state.genre,
   };
 }
 // this is how the picker tells redux that the user has selected a new player mode
@@ -120,18 +84,6 @@ function mapDispatchToProps(dispatch) {
       dispatch({
         type: "SET_MODAL_VISIBLE",
         modalVisible: visible,
-      });
-    },
-    setGenre: (genre) => {
-      dispatch({
-        type: "SET_GENRE",
-        genre: genre,
-      });
-    },
-    setGenreTypes: (genreTypes) => {
-      dispatch({
-        type: "SET_GENRE_TYPES",
-        genreTypes: genreTypes,
       });
     },
   };

--- a/Scenes/Question.js
+++ b/Scenes/Question.js
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { StyleSheet, View, ScrollView, Text } from "react-native";
 import AppLoading from "expo-app-loading";
 import { useFonts, Limelight_400Regular } from "@expo-google-fonts/limelight";
@@ -12,7 +12,9 @@ import Badge from "../Components/Badge";
 import Lives from "../Components/Lives";
 import DriveInMovie from "../Layout/DriveInMovie";
 
-function Question({ selectedMovie, movies, setMovies, gamePlayMode }) {
+function Question({ selectedMovie, movies, setMovies, gamePlayMode, genre }) {
+const [filteredMovies, setFilteredMovies] = useState(null)
+
   useEffect(() => {
     FetchApi().then((res) => {
       setMovies(res);
@@ -23,10 +25,18 @@ function Question({ selectedMovie, movies, setMovies, gamePlayMode }) {
     Limelight_400Regular,
   });
 
+  useEffect(()=>{
+    if(genre !== null){
+      setFilteredMovies( movies.filter((movie)=>{
+        return movie.genre_ids.includes(genre.id) 
+      }))
+    }
+  }, [genre])
+
   if (!fontsLoaded) {
     return <AppLoading />;
   } else if (Object.keys(selectedMovie).length === 0) {
-    return <GenerateQuestion movies={movies} />;
+    return <GenerateQuestion movies={filteredMovies !== null ? filteredMovies : movies} />;
   } else {
     return (
       <DriveInMovie
@@ -71,6 +81,7 @@ function mapStateToProps(state) {
     selectedMovie: state.selectedMovie,
     scene: state.scene,
     gamePlayMode: state.gamePlayMode || "easySinglePlayer",
+    genre: state.genre,
   };
 }
 

--- a/Scenes/Question.js
+++ b/Scenes/Question.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { StyleSheet, View, ScrollView, Text } from "react-native";
 import AppLoading from "expo-app-loading";
 import { useFonts, Limelight_400Regular } from "@expo-google-fonts/limelight";
@@ -12,9 +12,7 @@ import Badge from "../Components/Badge";
 import Lives from "../Components/Lives";
 import DriveInMovie from "../Layout/DriveInMovie";
 
-function Question({ selectedMovie, movies, setMovies, gamePlayMode, genre }) {
-const [filteredMovies, setFilteredMovies] = useState(null)
-
+function Question({ selectedMovie, movies, setMovies, gamePlayMode }) {
   useEffect(() => {
     FetchApi().then((res) => {
       setMovies(res);
@@ -25,18 +23,10 @@ const [filteredMovies, setFilteredMovies] = useState(null)
     Limelight_400Regular,
   });
 
-  useEffect(()=>{
-    if(genre !== null){
-      setFilteredMovies( movies.filter((movie)=>{
-        return movie.genre_ids.includes(genre.id) 
-      }))
-    }
-  }, [genre])
-
   if (!fontsLoaded) {
     return <AppLoading />;
   } else if (Object.keys(selectedMovie).length === 0) {
-    return <GenerateQuestion movies={filteredMovies !== null ? filteredMovies : movies} />;
+    return <GenerateQuestion movies={movies} />;
   } else {
     return (
       <DriveInMovie
@@ -81,7 +71,6 @@ function mapStateToProps(state) {
     selectedMovie: state.selectedMovie,
     scene: state.scene,
     gamePlayMode: state.gamePlayMode || "easySinglePlayer",
-    genre: state.genre,
   };
 }
 

--- a/Utils/FetchApi.js
+++ b/Utils/FetchApi.js
@@ -1,16 +1,21 @@
 import axios from "axios";
 
 export default async function FetchApi() {
-  let movies = [];
-
-  await axios
+  let moviesResponse = await axios.all([...Array(10)].map((item, index) =>{
+    return axios
     .get(
-      "https://api.themoviedb.org/3/movie/popular?api_key=59a35a38a15babb3dad4e83c83a72748&language=en-US"
+      `https://api.themoviedb.org/3/movie/popular?api_key=59a35a38a15babb3dad4e83c83a72748&language=en-US&page=${index + 1}`
     )
-    .then((res) => (movies = res.data.results))
+    .then((res) => (moviesResponse = res.data.results))
     .catch((err) => console.log(err.response.data));
 
-  return movies;
+  }));
+  let moviesList = []
+  moviesResponse.forEach((movieList) => {
+    moviesList = moviesList.concat(movieList)
+  });
+
+  return moviesList;
 }
 
 export async function getPerformerName(movieId) {


### PR DESCRIPTION
## Changes

1. FetchApi.js
2. Question.js
3. SettingsModal.js

## Purpose

Originally the purpose of this ticket was to fetch the genres of all movies from the API and create a feature where the user could pick a genre and during the gameplay the questions would correlate to whatever genre the user picked, but after completing the ticket we realized there was going to be a lot more complexity than expected so we decided to prune the feature as a whole. With that being said, while creating the ticket we modified the fetch to be able to dynamically change the amount of pages the fetch was pulling from the API which is the main reason we are still pushing this ticket up to develop.

## Approach

The approach we had in completing this ticket was to find a genre endpoint and succesfully fetch from that endpoint to filter the questions based on what the genre the user wanted to pick.

## Learning

While working on this ticket we learned that there is too much complexity within the scope of this feature to fully implement within our game. We were able to complete the ticket but there would have to be many more feature tickets to make the game as functional as we would want it. So to wrap things up the only thing being pushed up form our branch will be a modified fetch we originally had which is more dynamic in terms of how many movies will be fetched form the API 

Closes #24 
