### PR TITLE
fix(settings modal): add the word settings to the top 186

### DIFF
--- a/Components/SettingsModal.js
+++ b/Components/SettingsModal.js
@@ -35,6 +35,7 @@ const SettingsModal = ({
             }}
           >
             <View style={styles.modalView}>
+            <Text style={[styles.settingHeader, styles.label]}>Settings</Text>
               <Pressable
                 style={styles.exit}
                 onPress={() => setModalVisible(!modalVisible)}
@@ -167,7 +168,12 @@ const styles = StyleSheet.create({
   exit: {
     alignSelf: "flex-end",
     marginRight: -10,
+    marginTop: -12,
+    marginBottom: 10,
   },
+  settingHeader: {
+    fontSize: 20,
+  }
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(SettingsModal);


### PR DESCRIPTION
## Changes


1. Added the word settings to the settings modal.

## Purpose

The settings modal was missing a header text.

## Approach

This adds the missing text.

Closes #186
