### PR TITLE
fix(game over): remove marginBottom from the Game Over text

### DIFF
--- a/Scenes/GameOver.js
+++ b/Scenes/GameOver.js
@@ -168,7 +168,6 @@ function mapDispatchToProps(dispatch) {
 const styles = StyleSheet.create({
   gameOverStyle: {
     fontSize: 28,
-    marginBottom: Platform.OS !== "web" ? 20 : 70,
     textAlign: "center",
     fontFamily: "Limelight_400Regular",
     color: "#292840",


### PR DESCRIPTION
## Changes

1. Removed `marginBottom` from the `gameOverStyle`

## Purpose

The `Text` component with a style of `gameOverStyle` was being pushed up from the `marginBottom` that was applied to it.

## Approach

Removing the `marginBottom` fixed the issue.


