### PR TITLE
fix(Correct answer): remove top margin from next question button

### DIFF
--- a/Scenes/CorrectAnswer.js
+++ b/Scenes/CorrectAnswer.js
@@ -74,7 +74,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: 15,
     borderRadius: 10,
     backgroundColor: "transparent",
-    marginTop: 50,
   },
   h2: {
     fontSize: 28,


### PR DESCRIPTION
## Changes
Remove top margin from Next Question button in Correct Answer Scene.

## Purpose

The Next Question button in Correct Answer, when it is in Landscape was not in view.  

## Approach

Remove top margin from Next Question button in Correct Answer Scene, to display.

Able to see the Next Question button, except in Galaxy Android fold, which is not a big user.

Closes #203
