### PR TITLE
Ajm 200 randomcast undefined bug

### DIFF
--- a/Components/GenerateQuestion.js
+++ b/Components/GenerateQuestion.js
@@ -18,7 +18,7 @@ const GenerateQuestion = ({ movies, setSelectedMovie, setScene}) => {
         }
       } else if (typeof value === 'object' && value !== null) {
         return hasValidValues(Object.values(value));
-      } else if (typeof value === 'undefined' || value === null || value === '') {
+      } else if (typeof value === 'undefined' || value === '') {
         return false;
       }
       return true

--- a/Components/GenerateQuestion.js
+++ b/Components/GenerateQuestion.js
@@ -2,15 +2,14 @@ import React, { useEffect } from "react";
 import { View, Alert } from "react-native";
 import madLibsArray from "../Utils/madLibsArray";
 import RandomGenerator from "../Utils/RandomGenerator";
-import { getGenreName } from "../Utils/FetchApi";
+import { getGenreName, getPerformerName } from "../Utils/FetchApi";
 import { connect } from "react-redux";
-import { getMovieChanges, getPerformerName } from "../Utils/FetchApi";
 import axios from "axios";
 import { Platform } from "expo-modules-core";
 
 const GenerateQuestion = ({ movies, setSelectedMovie, setScene}) => {
-  const hasValidValues = (valuesList) => {
-    return valuesList.every((value) => {
+  const hasValidValues = (valuesList) => 
+    valuesList.every((value) => {
       if (Array.isArray(value)) {
         if (value.length === 0) {
           return false;
@@ -24,26 +23,19 @@ const GenerateQuestion = ({ movies, setSelectedMovie, setScene}) => {
       }
       return true
     });
-  }
   
   useEffect(() => {
-    let count = 0;
-    
     const generateQuestionAndCheckUndefined = async () => {
+      let count = 0;
       let isValid = false;
       let newMovie = await fetchNewMovie();
 
       while (!isValid && count < 2) {
-        if (isValid) {
-          isValid = true;
-        } else {
-          const movieQueryValues = Object.values(newMovie);
-
-          isValid = hasValidValues(movieQueryValues);
-          if (!isValid) {
-            newMovie = await fetchNewMovie();
-            count++;
-          }
+        const movieQueryValues = Object.values(newMovie);
+        isValid = hasValidValues(movieQueryValues);
+        if (!isValid) {
+          newMovie = await fetchNewMovie();
+          count++;
         }
       }
 
@@ -53,8 +45,7 @@ const GenerateQuestion = ({ movies, setSelectedMovie, setScene}) => {
 Press OK to return to the main screen.`);
           setScene("Main");
         }
-
-        if (Platform.OS !== "web") {
+        else {
           Alert.alert(
             "ERROR: Found too much missing data.",
             "Press OK to return to the main screen.",
@@ -64,7 +55,7 @@ Press OK to return to the main screen.`);
                 onPress: () => setScene("Main"),
               }
             ]
-          )
+          );
         }
       } else {
         let questionObject = madLibsArray(newMovie);
@@ -93,7 +84,6 @@ Press OK to return to the main screen.`);
 function mapStateToProps(state) {
   return {
     selectedMovie: state.selectedMovie,
-    genreName: state.genreName,
   };
 }
 
@@ -103,11 +93,6 @@ function mapDispatchToProps(dispatch) {
       dispatch({
         type: "SET_SELECTED_MOVIE",
         selectedMovie,
-      }),
-    setGenreName: (genreName) =>
-      dispatch({
-        type: "SET_GENRE_NAME",
-        genreName,
       }),
     setScene: (name) =>
       dispatch({

--- a/Components/GenerateQuestion.js
+++ b/Components/GenerateQuestion.js
@@ -15,7 +15,7 @@ const GenerateQuestion = ({ movies, setSelectedMovie, setScene}) => {
         return hasValidValues(value);
       } else if (typeof value === 'object' && value !== null) {
         return hasValidValues(Object.values(value));
-      } else if (value === 'undefined' || value === '') {
+      } else if (typeof value === 'undefined' || value === null || value === '') {
         return false;
       }
       return true

--- a/Components/GenerateQuestion.js
+++ b/Components/GenerateQuestion.js
@@ -19,7 +19,7 @@ const GenerateQuestion = ({ movies, setSelectedMovie, setScene}) => {
         }
       } else if (typeof value === 'object' && value !== null) {
         return hasValidValues(Object.values(value));
-      } else if (typeof value === 'undefined' || value === '') {
+      } else if (typeof value === 'undefined' || value === null || value === '') {
         return false;
       }
       return true
@@ -80,9 +80,8 @@ Press OK to return to the main screen.`);
         .all([getPerformerName(movie.id), getGenreName(movie.genre_ids[0])])
         .then(
           axios.spread((castRes, genreRes) => {
-            movie = { ...movie, cast: castRes.data.cast.slice(0, 2), genre: genreRes };
-            return movie;
-      }))
+            return { ...movie, cast: castRes.data.cast.slice(0, 10), genre: genreRes };
+      }));
     };
     
     generateQuestionAndCheckUndefined();  

--- a/Components/GenerateQuestion.js
+++ b/Components/GenerateQuestion.js
@@ -12,10 +12,14 @@ const GenerateQuestion = ({ movies, setSelectedMovie, setScene}) => {
   const hasValidValues = (valuesList) => {
     return valuesList.every((value) => {
       if (Array.isArray(value)) {
-        return hasValidValues(value);
+        if (value.length === 0) {
+          return false;
+        } else {
+          return hasValidValues(value);
+        }
       } else if (typeof value === 'object' && value !== null) {
         return hasValidValues(Object.values(value));
-      } else if (typeof value === 'undefined' || value === null || value === '') {
+      } else if (typeof value === 'undefined' || value === '') {
         return false;
       }
       return true

--- a/Components/GenerateQuestion.js
+++ b/Components/GenerateQuestion.js
@@ -32,12 +32,13 @@ const GenerateQuestion = ({ movies, setSelectedMovie, setScene}) => {
     const generateQuestionAndCheckUndefined = async () => {
       let isValid = false;
       let newMovie = await fetchNewMovie();
-      const movieQueryValues = Object.values(newMovie);
 
       while (!isValid && count < 2) {
         if (isValid) {
           isValid = true;
         } else {
+          const movieQueryValues = Object.values(newMovie);
+
           isValid = hasValidValues(movieQueryValues);
           if (!isValid) {
             newMovie = await fetchNewMovie();

--- a/Components/GenerateQuestion.js
+++ b/Components/GenerateQuestion.js
@@ -66,7 +66,9 @@ Press OK to return to the main screen.`);
           )
         }
       } else {
-        setSelectedMovie(newMovie);
+        let questionObject = madLibsArray(newMovie);
+        let randomIndex = RandomGenerator(questionObject.length);
+        setSelectedMovie(questionObject[randomIndex]);
       }
     }
 
@@ -78,10 +80,7 @@ Press OK to return to the main screen.`);
         .then(
           axios.spread((castRes, genreRes) => {
             movie = { ...movie, cast: castRes.data.cast.slice(0, 2), genre: genreRes };
-            let questionObject = movie ? madLibsArray(movie) : {};
-            let randomIndex = RandomGenerator(questionObject.length);
-            
-            return questionObject[randomIndex];
+            return movie;
       }))
     };
     


### PR DESCRIPTION
## Changes

1. GenerateQuestion.js

## Purpose

This fix deals with checking the currently selected movie for empty values before constructing questions.
The selected movie needs to be checked before using it to construct questions in `madLibsArray.js`
If the selected movie contains empty values ('', [], {}, null, undefined), we'll need to try again with another movie from the movies array.

## Approach

Refactored the recursive solution implemented by #188 into three separate functions (hasValidValues, generateQuestionAndCheckUndefined, fetchNewMovie). generateQuestionAndCheckUndefined() first calls fetchNewMovie() to select a random movie from the movies array. Additional data such as cast and genres are fetched and appended to it. Then a loop is run that utilizes a helper function, hasValidValues(), to check for empty or undefined values via recursion. If the movie object contains empty or undefined values, a new movie is selected and a counter is incremented. The loop repeats until a movie with valid values is found or the counter reaches 2.

The question can now be constructed with a valid movie object. Otherwise an error dialog is shown, prompting the user to restart.
A side note, in fetchNewMovie(), the cast array is pruned to the first ten entries to reduce time complexity in hasValidValues

## Learning
none

Closes #200
