### PR TITLE
fix(ios footer): add conditional space between | and A also | and H in the footer

### DIFF
--- a/Layout/Footer.js
+++ b/Layout/Footer.js
@@ -1,4 +1,4 @@
-import { StyleSheet, View, Text, Pressable } from "react-native";
+import { StyleSheet, View, Text, Pressable, Platform } from "react-native";
 import { connect } from "react-redux";
 
 function Footer({ setScene }) {
@@ -9,11 +9,11 @@ function Footer({ setScene }) {
       </Pressable>
       <Text style={styles.textColor}> | </Text>
       <Pressable onPress={() => setScene("About")}>
-        <Text style={styles.textColor}>About</Text>
+        <Text style={styles.textColor}>{Platform.OS === 'ios' ? " " : ""}About</Text>
       </Pressable>
       <Text style={styles.textColor}> | </Text>
       <Pressable onPress={() => setScene("HowToPlay")}>
-        <Text style={styles.textColor}>How To Play</Text>
+        <Text style={styles.textColor}>{Platform.OS === 'ios' ? " " : ""}How To Play</Text>
       </Pressable>
     </View>
   );


### PR DESCRIPTION
## Changes

1. Import `Platform` from `react-native`
2. Use `Platform.OS` to add a space for `ios` only

## Purpose

The space between `|` and `A` also `|` and `H` was rendering with less space than Android and Web.

## Approach

This allows for iOS to display a space to render in a similar way to Android and Web.

Closes #212
